### PR TITLE
Suggested change to handle comma-separated item lists.

### DIFF
--- a/java/src/jmri/jmrit/symbolicprog/VariableTableModel.java
+++ b/java/src/jmri/jmrit/symbolicprog/VariableTableModel.java
@@ -397,8 +397,8 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
         @SuppressWarnings("unchecked")
         List<Element> elements = e.getChildren("defaultItem");
         for (Element defaultItem : elements) {
-            String include = defaultItem.getAttribute("include").getValue();
-            if (include.equals(_df.getProductID()) || include.equals(_df.getModel()) || include.equals(_df.getFamily()) ) {
+            if (_df != null && DecoderFile.isIncluded(defaultItem, _df.getProductID(), _df.getModel(), _df.getFamily(), "", "")) {
+                log.debug("element included by productID={} model={} family={}", _df.getProductID(), _df.getModel(), _df.getFamily());
                 v.setIntValue(Integer.parseInt(defaultItem.getAttribute("default").getValue()));
                 return true;
             }


### PR DESCRIPTION
Suggested change to handle comma-separated item lists in both productID and include/exclude.

This brings include/exclude processing into line with variables, panes, groups., enumChoice etc.

Resolves problem with definitions having multiple productIDs (e.g. ESU) and also provides for @mmosher5501 original request for comma-separated includes.

Also allows for exclude; use this value for everything except "...".