### PR TITLE
More tweaks to schema for defaultItem.

### DIFF
--- a/xml/schema/decoder-4-13-3.xsd
+++ b/xml/schema/decoder-4-13-3.xsd
@@ -649,10 +649,10 @@
                   <xs:element name="defaultItem" minOccurs="0" maxOccurs="unbounded" >
                     <xs:annotation><xs:documentation>
                     Specifies the default value to use when the decoder family/model/productID has a specific value.
-                    Both attributes are required.
+                    Either or both of "include" and "exclude" can be specified.
                     </xs:documentation></xs:annotation>
                     <xs:complexType>
-                      <xs:attribute name="default" type="xs:int"/>
+                      <xs:attribute name="default" type="xs:int" use="required"/>
                       <xs:attribute name="include" type="xs:string" default=""/>
                       <xs:attribute name="exclude" type="xs:string" default=""/>
                     </xs:complexType>


### PR DESCRIPTION
Does this clarify?

The code in  DecoderFile doesn't actually require a default for either of include/exclude:
```
        String include = e.getAttributeValue("include");
        if (include != null) {
            include = include + "," + extraInclude;
        } else {
            include = extraInclude;
        }
        // if there are any include clauses, then it has to match
        if (!include.equals("") && !(isInList(productID, include) || isInList(modelID, include) || isInList(familyID, include))) {
            ...
        }

        String exclude = e.getAttributeValue("exclude");
        if (exclude != null) {
            exclude = exclude + "," + extraExclude;
        } else {
            exclude = extraExclude;
        }
        // if there are any exclude clauses, then it cannot match
        if (!exclude.equals("") && (isInList(productID, exclude) || isInList(modelID, exclude) || isInList(familyID, exclude))) {
                ...
            }
```