### PR TITLE
Suggest different labels for PRs + questions

### DIFF
--- a/help/en/html/doc/Technical/ReleaseProcess.md
+++ b/help/en/html/doc/Technical/ReleaseProcess.md
@@ -20,21 +20,28 @@ _Before_ a release, the development installers will be named with the branch bei
 
 Each PR that's merged for inclusion can require an increment of the first, second or third digit.  For this to work, we need a very reliable way to identify the right one, and make sure it takes effect.
 
- - We'll define three new labels for GitHub PRs:  Major Change, Minor Change, Update Only
+ - We'll define four new labels for GitHub PRs:
+   - _Breaking Change_ - requires a major version change because it breaks outside code
+   - _Feature_ - changes the visible API
+   - _Fix_ - no change to visible API, but triggers a version change absent other non-chore changes
+   - _Chore_ - no change to Java code or published artifacts (e.g. updates build scripts and CI processes), does not trigger version change
  - A PR must have exactly one of those applied for it to be merged
  - The author of the PR can propose a label, in which case only one reviewer is required.
  - If the author of the PR does not propose a label, two reviewers must sign off on the right label.
  
- Since we'll now be requiring a review, the reviewer can also encourage reasonable additions to the release note. A more-automated process for creating release notes with useful content would help this succeed.
- 
+Since we'll now be requiring a review, the reviewer can also encourage reasonable additions to the release note. A more-automated process for creating release notes with useful content would help this succeed.
+
+__Question__: if the first commit to a PR follows [Conventional Commits rules](https://www.conventionalcommits.org/en/v1.0.0/), can that be a replacement for the label?
+
 ## Use of Git to Accumulate Changes
  
  - The HEAD of `JMRI/master` will always be the most highest numbered release made so far
      - Usually this is the last
      - But if 5.3.1 is released after 5.4.0 or even 6.0.0 is released, those will remain HEAD of master
      - This means that new Git users who checkout `master` will be working on a mergeable base for the next release(s)
-  - PRs labeled with 'Major Change' will be merged to a 'dev-major' branch, those labeled 'Minor Change' will be merged to a 'dev-minor' branch and those labeled with 'Update Only'  will be merged to a 'dev-update' branch. 
+  - PRs labeled with _Breaking Change_ will be merged to a 'dev-major' branch, those labeled _Feature_ will be merged to a 'dev-minor' branch and those labeled with _Fix_ will be merged to a 'dev-update' branch.
   - Often, those perhaps not on every PR, the branches will be merged upwards: dev-update into dev-minor, dev-minor into dev-major
+  - __Question__ Do _Chore_ PRs just get committed to master?
   
 The goal of this is to make it possible to work on i.e. updates from a stable base of either the last numbered release (`master`, which people get by default) or the current contents of the relevant branch.  Because it makes all three branches available, it allows accumulating and collaborating on all three kinds of changes.
 
@@ -52,13 +59,13 @@ How do we decide when to do that if we don't have a monthly cadence?
  
  - How often (on what basis) should we be creating "Major Change" branch releases, hence updating that digit? Since we distribute applications to users, who are primarily _application_ users, most major changes may not even be visible.  We need to get them out to people before too much change accumulates, but too many might discourage people.  Maybe every three months? Six months?
 
- - What process is needed to identify when a release is good enough as one that should be made the default? Both the large scale, so we can talk in advance about the "2020-Oct" release, and at the event, as we try to get something usable to converge. For the last few years, we've needed several test releases to converge on a quality level; June 2020 was no different in that respect. How do we get that done in this model?
+ - What process is needed to identify when a release is good enough as one that should be made the default? Both the large scale, so we can talk in advance about the "October 2020" (2020-10) release, and at the event, as we try to get something usable to converge. For the last few years, we've needed several test releases to converge on a quality level; June 2020 was no different in that respect. How do we get that done in this model?
  
 ## Other questions?
 
  - What should populate the web? 
    - By doing that from `master`, it'll automatically be stable; some people like that.
-   - We don't know a-priori what will be released next, so we can't populate it from the _next__ changes as they're developed
+   - We don't know a-priori what will be released next, so we can't populate it from the _next_ changes as they're developed
    - If desired, we could have all four (master, dev-major, dev-minor, dev-branch) on the web at slightly different URLs; that just moves the question to which should be the default
     
 
@@ -66,7 +73,7 @@ How do we decide when to do that if we don't have a monthly cadence?
  
 JMRI has, for a long time, followed a Linux-like release numbering system where odd-numbered minor releases were for development and tests, whilst even numbered releases were for production. That distinction is no longer present here.
 
-There is no longer an explicit [deprecation cycle](https://www.jmri.org/help/en/html/doc/Technical/RP.shtml#deprecating). One can certain mark parts of the API as deprecated in a update or minor change; that's polite.  But when the change gets into the major branch, the deprecations should have bee removed:  A breaking change is a breaking change.
+There is no longer an explicit [deprecation cycle](https://www.jmri.org/help/en/html/doc/Technical/RP.shtml#deprecating). One can certain mark parts of the API as deprecated in a update or minor change; that's polite.  But when the change gets into the major branch, the deprecations should have been removed:  A breaking change is a breaking change.
 
 This entire system is well suited to "point" releases to fix things.  For example, say the most recent releases have been 5.6.3, 5.7.0 and 6.0.0.  Then
  - Jim finds a bug and fixes it starting with master (5.6.6)


### PR DESCRIPTION
I suggest that the labels be more descriptive than _Major_/_Minor_/_Update_ and to match the Conventional Commits rules since there is existing tooling that can be used to read conventional commits and increment versions and build release notes based on those commits.

I'm not 100% the _Chore_ commit should not be rolled up into _Fix_, but included it since we may want to distinguish those type of PRs from others.