### PR TITLE
Proposed answer on where to merge Chore PRs

### DIFF
--- a/help/en/html/doc/Technical/ReleaseProcess.md
+++ b/help/en/html/doc/Technical/ReleaseProcess.md
@@ -41,7 +41,8 @@ __Question__: if the first commit to a PR follows [Conventional Commits rules](h
      - This means that new Git users who checkout `master` will be working on a mergeable base for the next release(s)
   - PRs labeled with _Breaking Change_ will be merged to a 'dev-major' branch, those labeled _Feature_ will be merged to a 'dev-minor' branch and those labeled with _Fix_ will be merged to a 'dev-update' branch.
   - Often, those perhaps not on every PR, the branches will be merged upwards: dev-update into dev-minor, dev-minor into dev-major
-  - __Question__ Do _Chore_ PRs just get committed to master?
+
+_Chore_ PRs should be put into affect in the infrastucture as soon as possible, but we don't want them to burden developers with minimal git capability, i.e. working directly from `master`. Hence they should be merged to the `dev-update`, and from there merged upward to the other branches as needed.  They'll then get back to `master` when a branch is next released. (Keeping master exactly fixed helps us check for and prevent inadvertant merges of other changes via PRs)
   
 The goal of this is to make it possible to work on i.e. updates from a stable base of either the last numbered release (`master`, which people get by default) or the current contents of the relevant branch.  Because it makes all three branches available, it allows accumulating and collaborating on all three kinds of changes.
 


### PR DESCRIPTION
The question was whether "Chore" PRs would go on the master branch.  I think that the master branch should stay clean in this model, so that we can easily do comparisons.  If I've started on master and make a change in bobj-pr, then these are all useful and interesting:
```
git diff master...bobj-pr
git diff bobj-pr...master
git diff bobj-pr...dev-major
git diff bobj-pr...dev-major
git diff bobj-pr...dev-major
```
The first is a check of what I think I'm contributing; the second is a check that I really started from master, and am not bringing in other stuff; and the last three check for conflicts that would prevent merging up the stack of branches.  Those last ones are _much_ easier to interpret if master only moves is a specifically known way.